### PR TITLE
Workaround: Make struct data in .rodata section aligned

### DIFF
--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -16,7 +16,11 @@ struct initcall {
 	int level;
 	const char *func_name;
 #endif
+#if defined(X86_64)
+} __aligned(32);
+#else
 };
+#endif
 
 #if TRACE_LEVEL >= TRACE_DEBUG
 #define __define_initcall(type, lvl, fn) \

--- a/core/include/kernel/pseudo_ta.h
+++ b/core/include/kernel/pseudo_ta.h
@@ -38,7 +38,11 @@ struct pseudo_ta_head {
 	TEE_Result (*invoke_command_entry_point)(void *pSessionContext,
 			uint32_t nCommandID, uint32_t nParamTypes,
 			TEE_Param pParams[TEE_NUM_PARAMS]);
+#if defined(X86_64)
+} __aligned(0x80);
+#else
 };
+#endif
 
 #define pseudo_ta_register(...)	\
 	SCATTERED_ARRAY_DEFINE_PG_ITEM(pseudo_tas, struct pseudo_ta_head) = \

--- a/core/include/kernel/ts_store.h
+++ b/core/include/kernel/ts_store.h
@@ -50,7 +50,11 @@ struct ts_store_ops {
 	 * Close a TS handle. Do nothing if @h == NULL.
 	 */
 	void (*close)(struct ts_store_handle *h);
+#if defined(X86_64)
+}__aligned(32);
+#else
 };
+#endif
 
 /*
  * Registers a TA storage.

--- a/core/include/scattered_array.h
+++ b/core/include/scattered_array.h
@@ -82,6 +82,16 @@
  * @array_name:   Name of the scattered array
  * @element_type: The type of the elemenet
  */
+#if defined(X86_64)
+#define SCATTERED_ARRAY_BEGIN(array_name, element_type) (__extension__({ \
+		static const element_type __scattered_array_begin[0] __aligned(32) __unused \
+		__section(".scattered_array_" #array_name "_0" \
+			  __SECTION_FLAGS_RODATA); \
+		\
+		(const element_type *)scattered_array_relax_ptr( \
+			__scattered_array_begin); \
+	}))
+#else
 #define SCATTERED_ARRAY_BEGIN(array_name, element_type) (__extension__({ \
 		static const element_type __scattered_array_begin[0] __unused \
 		__section(".scattered_array_" #array_name "_0" \
@@ -90,6 +100,7 @@
 		(const element_type *)scattered_array_relax_ptr( \
 			__scattered_array_begin); \
 	}))
+#endif
 
 /*
  * Returns one entry past the last element in a scattered array

--- a/core/kernel/pseudo_ta.c
+++ b/core/kernel/pseudo_ta.c
@@ -261,6 +261,19 @@ static TEE_Result verify_pseudo_tas_conformance(void)
 	const struct pseudo_ta_head *end =
 		SCATTERED_ARRAY_END(pseudo_tas, struct pseudo_ta_head);
 	const struct pseudo_ta_head *pta;
+#if defined(X86_64)
+	uint32_t pth_size = sizeof(struct pseudo_ta_head);
+	uint64_t align_start = (uint64_t)start;
+	/* Workaround:
+	   In the tee.dmp, we found that __scattered_array_begin was not equal
+	   to the first TA __scattered_array_0pseudo_tas address. Thus, access
+	   psedudo TA via __scattered_array_begin would be wrong.
+	   So make the WA to make them align.
+	   TODO: fix the WA
+	*/
+	align_start = ROUNDUP(align_start, pth_size);
+	start = (const struct pseudo_ta_head *)align_start;
+#endif
 
 	for (pta = start; pta < end; pta++) {
 		const struct pseudo_ta_head *pta2;
@@ -295,10 +308,26 @@ TEE_Result tee_ta_init_pseudo_ta_session(const TEE_UUID *uuid,
 	struct pseudo_ta_ctx *stc = NULL;
 	struct tee_ta_ctx *ctx;
 	const struct pseudo_ta_head *ta;
+#if defined(X86_64)
+	uint32_t pth_size = sizeof(struct pseudo_ta_head);
+	uint64_t align_start;
+#endif
 
 	DMSG("Lookup pseudo TA %pUl", (void *)uuid);
 
 	ta = SCATTERED_ARRAY_BEGIN(pseudo_tas, struct pseudo_ta_head);
+#if defined(X86_64)
+	/* Workaround:
+	   In the tee.dmp, we found that __scattered_array_begin was not equal
+	   to the first TA __scattered_array_0pseudo_tas address. Thus, access
+	   psedudo TA via __scattered_array_begin would be wrong.
+	   So make the WA to make them align.
+	   TODO: fix the WA
+	*/
+	align_start = (uint64_t)ta;
+	align_start = ROUNDUP(align_start, pth_size);
+	ta = (const struct pseudo_ta_head *)align_start;
+#endif
 	while (true) {
 		if (ta >= SCATTERED_ARRAY_END(pseudo_tas,
 					      struct pseudo_ta_head))


### PR DESCRIPTION
register_phys_mem_ul() will put struct data to .rodata sections.
But the struct are automatic 32/64/128 aligned. This is the
patch to make pointer to get correct data in .rodata section

Signed-off-by: Chen Gang G <gang.g.chen@intel.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
