### PR TITLE
Fix several TAs parallel enter user mode page fault issue

### DIFF
--- a/core/arch/x86_64/kernel/thread.c
+++ b/core/arch/x86_64/kernel/thread.c
@@ -717,7 +717,7 @@ int thread_state_suspend(uint32_t flags, vaddr_t sp)
 	return ct;
 }
 
-void thread_state_save(vaddr_t sp, uint32_t client)
+void thread_state_save(vaddr_t sp)
 {
 	struct thread_core_local *l = thread_get_core_local();
 	int ct = l->curr_thread;
@@ -728,14 +728,9 @@ void thread_state_save(vaddr_t sp, uint32_t client)
 
 	assert(threads[ct].state == THREAD_STATE_ACTIVE);
 
-	if (client == TEE_LOGIN_TRUSTED_APP) {
-		threads[ct].ta_idx++;
-		assert(threads[ct].ta_idx < MAX_TA_IDX+1);
-		threads[ct].stack_va_curr[threads[ct].ta_idx-1] = sp;
-	} else {
-		threads[ct].ta_idx = 1;
-		threads[ct].stack_va_curr[0] = sp;
-	}
+	threads[ct].ta_idx++;
+	assert(threads[ct].ta_idx < MAX_TA_IDX+1);
+	threads[ct].stack_va_curr[threads[ct].ta_idx-1] = sp;
 
 	syscall_init(sp - 64);
 

--- a/core/arch/x86_64/kernel/thread_64.S
+++ b/core/arch/x86_64/kernel/thread_64.S
@@ -275,8 +275,6 @@ FUNC __thread_enter_user_mode , :
 
     movq %rsp, %rdi
 
-    movq 56(%r13), %rsi    // client
-
     cli
     call thread_state_save
 

--- a/core/arch/x86_64/kernel/thread_private.h
+++ b/core/arch/x86_64/kernel/thread_private.h
@@ -145,7 +145,7 @@ int thread_state_suspend(uint32_t flags, vaddr_t sp);
 /*
  * Save the state of current thread
  */
-void thread_state_save(vaddr_t sp, uint32_t client);
+void thread_state_save(vaddr_t sp);
 
 /*
  * Marks the current thread as free.

--- a/core/kernel/user_ta.c
+++ b/core/kernel/user_ta.c
@@ -163,8 +163,6 @@ static TEE_Result user_ta_enter(struct ts_session *session,
 	else
 		memset(usr_params, 0, sizeof(*usr_params));
 
-	ta_sess->ts_sess.handle_svc();
-
 	res = thread_enter_user_mode(func, kaddr_to_uref(session),
 				     (vaddr_t)usr_params, cmd, usr_stack,
 				     utc->uctx.entry_func, utc->uctx.is_32bit,


### PR DESCRIPTION
The fix solves xtest 1006 test case. In the test case, a TA
needs to open another TA. Thus, at least 2 TAs enter into
user space. The patch fix TA stack restore issue

Signed-off-by: Chen Gang G <gang.g.chen@intel.com>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
