### PR TITLE
port 2 patches

### DIFF
--- a/core/arch/x86_64/kernel/link.mk
+++ b/core/arch/x86_64/kernel/link.mk
@@ -78,7 +78,7 @@ $(link-out-dir)/init_entries.txt: $(link-out-dir)/all_objs.o
 	$(q)$(NMcore) $< | \
 		$(AWK) '/ ____keep_init/ { printf "-u%s ", $$3 }' > $@
 
-init-ldargs := -T $(link-script-dummy) --no-check-sections --gc-sections
+init-ldargs := -T $(link-script-dummy) --no-check-sections
 init-ldadd := $(link-objs-init) $(link-out-dir)/version.o  $(link-ldadd) \
 	      $(libgcccore)
 cleanfiles += $(link-out-dir)/init.o

--- a/lib/libmbedtls/core/sm2-dsa.c
+++ b/lib/libmbedtls/core/sm2-dsa.c
@@ -139,6 +139,7 @@ out:
 	mbedtls_mpi_free(&r);
 	mbedtls_mpi_free(&s);
 	mbedtls_mpi_free(&tmp);
+	mbedtls_ecp_group_free(&grp);
 	return res;
 }
 
@@ -262,5 +263,6 @@ out:
 	mbedtls_mpi_free(&t);
 	mbedtls_mpi_free(&eprime);
 	mbedtls_mpi_free(&R);
+	mbedtls_ecp_group_free(&grp);
 	return res;
 }

--- a/lib/libmbedtls/core/sm2-pke.c
+++ b/lib/libmbedtls/core/sm2-pke.c
@@ -446,5 +446,7 @@ out:
 	mbedtls_ecp_point_free(&x2y2p);
 	mbedtls_ecp_point_free(&PB);
 	mbedtls_ecp_point_free(&C1);
+	mbedtls_ecp_group_free(&grp);
+	mbedtls_mpi_free(&k);
 	return res;
 }

--- a/mk/compile.mk
+++ b/mk/compile.mk
@@ -26,6 +26,11 @@ comp-cflags$(sm)	+= -Werror
 endif
 comp-cflags$(sm)  	+= -fdiagnostics-show-option
 
+# TODO: Enable stack protector when OPTEE x86_64 suppports.
+ifeq ($(CFG_X86_64_core),y)
+comp-cflags$(sm)	+= -fno-stack-protector
+endif
+
 comp-cflags-warns-high = \
 	-Wall -Wcast-align  \
 	-Werror-implicit-function-declaration -Wextra -Wfloat-equal \


### PR DESCRIPTION
port 2 patches
1. fix mbedtls memory leak
2. support common gcc toolchain